### PR TITLE
changed doublet_h5ad to output_h5ad in main.nf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -44,7 +44,7 @@ workflow {
 
     // Optional: aggregate the outputs
     if (params.aggregation) {
-        AGGREGATION(DOUBLETDETECTION.out.doublet_h5ad.collect())
+        AGGREGATION(DOUBLETDETECTION.out.output_h5ad.collect())
         outlier_input = AGGREGATION.out
     } else {
         outlier_input = DOUBLETDETECTION.out


### PR DESCRIPTION
the output variable of process `DOUBLETDETECTION` is named `output_h5ad`, but it is referenced in `main.nf` as `doublet_h5ad`, causing an error if the pipeline is run with aggregation. this renames the reference to `output_h5ad`.