### PR TITLE
added cellbender empty_drop_training_fraction as param

### DIFF
--- a/bin/run_cellbender.py
+++ b/bin/run_cellbender.py
@@ -15,6 +15,7 @@ parser.add_argument(
     help="Estimate of total number of droplets.",
 )
 parser.add_argument("--filtered", nargs="*", help="Path to filtered cellranger output.")
+parser.add_argument("--empty_drop_training_fraction", default=0.2, type=float)
 
 args = parser.parse_args()
 
@@ -30,7 +31,8 @@ cellbender remove-background \
       --input {args.raw_h5} \
       --output {args.output_h5} \
       --expected-cells {expected_cells} \
-      --total-droplets-included {args.total_droplets_included}
+      --total-droplets-included {args.total_droplets_included} \
+      --empty-drop-training-fraction {args.empty_drop_training_fraction}
 """
 
 print(command)

--- a/modules/cellbender/main.nf
+++ b/modules/cellbender/main.nf
@@ -1,7 +1,7 @@
 process CELLBENDER {
     label 'gpus'
     container 'us.gcr.io/broad-dsde-methods/cellbender:latest'
-    containerOptions '--nv --bind ${params.mount}'
+    containerOptions "--nv --bind ${params.mount}"
     publishDir "${params.outdir}/rna_cellbender/", mode: 'copy'
     cache 'lenient'
 
@@ -20,7 +20,8 @@ process CELLBENDER {
             ${raw_path} \
             ${name}_cellbender.h5 \
             ${expected_droplets} \
-            --filtered ${filtered_path}
+            --filtered ${filtered_path} \
+            --empty_drop_training_fraction ${params.cellbender.empty_drop_training_fraction}
         """
     else
         """
@@ -28,6 +29,7 @@ process CELLBENDER {
             ${raw_path} \
             ${name}_cellbender.h5 \
             ${expected_droplets} \
-            --filtered ${filtered_path}
+            --filtered ${filtered_path} \
+            --empty_drop_training_fraction ${params.cellbender.empty_drop_training_fraction}
         """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,6 +3,7 @@ params {
     experiment.name = "nf-scrnaseq"
     aggregation = true
     atac = false
+    cellbender.empty_drop_training_fraction = 0.2
     remove_doublets = false
     remove_outliers = false
     scvi.n_latent = 50


### PR DESCRIPTION
I was running into the error described here (fewer than 4 cells passed to encoder minibatch):
https://github.com/broadinstitute/CellBender/issues/255

The developer provided the solution of reducing the cellbender `--empty-drop-training-fraction` parameter from its default of 0.2 to 0.1, which worked for me. This PR allows this argument to be specified in the params file.

Also, I ran into a bug with the single quotes in `containerOptions '--nv --bind ${params.mount}'`; when I changed it to double quotes, the bug went away.