### PR TITLE
Support HVG batch key specification for demultiplexed data 

### DIFF
--- a/bin/postprocessing.py
+++ b/bin/postprocessing.py
@@ -73,23 +73,9 @@ parser.add_argument(
     action=argparse.BooleanOptionalAction,
     help="Use SCVI latent variable instead of PCA.",
 )
-parser.add_argument(
-    "--metadata", required=False, default="None", help="Metadata to be added to obs."
-)
 args = parser.parse_args()
 
 adata = sc.read_h5ad(args.input_h5ad)
-
-if not args.metadata == "None":
-    print("Reading the metadata...")
-    metadata = pd.read_csv(args.metadata)
-    new_cols = [x for x in metadata.columns if x not in adata.obs.columns]
-    intersect_cols = [x for x in metadata.columns if x in adata.obs.columns]
-    metadata = adata.obs.merge(metadata, how="left", on=intersect_cols)
-    assert metadata.shape[0] == adata.shape[0]
-    metadata.index = adata.obs.index
-    for new_col in new_cols:
-        adata.obs[new_col] = metadata[new_col]
 
 if not args.use_scvi:
     norm_df = pd.DataFrame(

--- a/bin/scvi_norm.py
+++ b/bin/scvi_norm.py
@@ -2,6 +2,7 @@ import scvi
 import scanpy as sc
 import argparse
 import torch
+import pandas as pd
 
 parser = argparse.ArgumentParser(
     description="wrapper for running SCVI on transcriptomic data."
@@ -18,6 +19,14 @@ parser.add_argument(
 parser.add_argument(
     "--n_top_genes", default=1000, type=int, required=False, help="Number of top genes."
 )
+parser.add_argument(
+    "--metadata", required=False, default="None", help="Metadata to be added to obs."
+)
+parser.add_argument(
+    "--sample_key",
+    default="sample_name",
+    help="Sample key to be used for highly variable genes.",
+)
 
 args = parser.parse_args()
 
@@ -27,15 +36,26 @@ adata = sc.read_h5ad(args.input)
 sc.pp.filter_cells(adata, min_genes=200)
 sc.pp.filter_genes(adata, min_cells=3)
 
+if not args.metadata == "None":
+    print("Reading the metadata...")
+    metadata = pd.read_csv(args.metadata)
+    new_cols = [x for x in metadata.columns if x not in adata.obs.columns]
+    intersect_cols = [x for x in metadata.columns if x in adata.obs.columns]
+    metadata = adata.obs.merge(metadata, how="left", on=intersect_cols)
+    assert metadata.shape[0] == adata.shape[0]
+    metadata.index = adata.obs.index
+    for new_col in new_cols:
+        adata.obs[new_col] = metadata[new_col]
+
 adata.layers["X_scran"] = adata.X.copy()
 sc.pp.log1p(adata, base=2)
-
+adata = adata[adata.obs[args.sample_key].notnull(), :].copy()
 sc.pp.highly_variable_genes(
     adata,
     n_top_genes=args.n_top_genes,
     layer="counts",
     flavor="seurat_v3",
-    batch_key="sample_name",
+    batch_key=args.sample_key,
     span=0.5,
 )
 
@@ -59,11 +79,13 @@ scvi.settings.seed = 18591124
 latent = model.get_latent_representation()
 
 scvi.settings.seed = 18591124
-denoised = model.get_normalized_expression(library_size=1e4)
+denoised = model.get_normalized_expression(library_size=1e4, return_numpy=True)
 
 scvi.settings.seed = 18591124
 integrated = model.get_normalized_expression(
-    transform_batch=adata.obs["sample_name"].unique().tolist(), library_size=1e4
+    transform_batch=adata.obs["sample_name"].unique().tolist(),
+    library_size=1e4,
+    return_numpy=True,
 )
 
 adata.obsm["X_scVI"] = latent

--- a/modules/postprocessing/main.nf
+++ b/modules/postprocessing/main.nf
@@ -14,11 +14,6 @@ process POSTPROCESSING {
     path "${name}_postprocessing_scvi.h5ad", emit: postprocessing_scvi_h5ad
 
     script:
-    def metaArg = ''
-    if (params.postprocessing.metadata &&
-        params.postprocessing.metadata.toString().toLowerCase() !in ['none', 'null', '']) {
-        metaArg = "--metadata ${params.postprocessing.metadata}"
-    }
     """
     export NUMBA_CACHE_DIR=\$PWD
     export MPLCONFIGDIR=\$PWD
@@ -26,13 +21,11 @@ process POSTPROCESSING {
         ${scvi_h5ad} \
         ${name}_postprocessing.h5ad \
         --n_pca_components ${params.postprocessing.n_pca_components} \
-        ${metaArg} \
         --leiden_res ${params.postprocessing.leiden_res}
     python ${baseDir}/bin/postprocessing.py \
         ${scvi_h5ad} \
         ${name}_postprocessing_scvi.h5ad \
         --use_scvi \
-        ${metaArg} \
         --leiden_res ${params.postprocessing.leiden_res}
     """
 }

--- a/modules/scvi/main.nf
+++ b/modules/scvi/main.nf
@@ -14,6 +14,16 @@ process SCVI {
     path "${name}_scvi.h5ad", emit: scvi_h5ad
 
     script:
+    def metaArg = ''
+    if (params.scvi.metadata &&
+        params.scvi.metadata.toString().toLowerCase() !in ['none', 'null', '']) {
+        metaArg = "--metadata ${params.scvi.metadata}"
+    }
+    def sampleKeyArg = ''
+    if (params.scvi.sample_key &&
+        params.scvi.sample_key.toString().toLowerCase() !in ['none', 'null', '']) {
+        sampleKeyArg = "--sample_key ${params.scvi.sample_key}"
+    }
     """
     export PYTHONNOUSERSITE=1
     export NUMBA_CACHE_DIR=\$PWD
@@ -21,6 +31,8 @@ process SCVI {
         ${scran_h5ad} \
         ${name}_scvi.h5ad \
         --n_latent ${params.scvi.n_latent} \
-        --n_top_genes ${params.scvi.n_top_genes}
+        --n_top_genes ${params.scvi.n_top_genes} \
+        ${metaArg} \
+        ${sampleKeyArg}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -74,7 +74,7 @@ profiles {
             time = params.max_time
             memory = params.max_memory
             withLabel: 'gpus' {
-                queue = 'chanj3'
+                queue = 'chanj3,gpu'
                 clusterOptions = '--gpus=1 --constraint=l40s'
             }
         }


### PR DESCRIPTION
This pull request introduces improvements to the pipeline configuration and metadata handling for the SCVI and postprocessing modules. The main changes enhance flexibility in passing metadata and sample key arguments, and update resource allocation for GPU jobs.

**SCVI and postprocessing argument handling:**

* Added support for optional `--metadata` and `--sample_key` arguments in the `SCVI` process, making it possible to pass metadata and sample key parameters dynamically if provided in `params.scvi` (`modules/scvi/main.nf`).
* Removed the construction and passing of the `--metadata` argument from the `POSTPROCESSING` process, simplifying its invocation and relying on upstream handling (`modules/postprocessing/main.nf`).

**Resource configuration:**

* Updated the GPU job queue to use `chanj3,gpu` instead of just `chanj3`, ensuring jobs are submitted to the correct queue for GPU resources (`nextflow.config`).